### PR TITLE
v0.3.6.10

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ToxicRagers"]
 	path = ToxicRagers
-	url = https://github.com/ErrolErrolson/ToxicRagers.git
+	url = https://github.com/MaxxWyndham/ToxicRagers.git

--- a/Flummery/ContentPipeline/Core/FBXImporter.cs
+++ b/Flummery/ContentPipeline/Core/FBXImporter.cs
@@ -66,6 +66,10 @@ namespace Flummery.ContentPipeline.Core
 
                 switch (Path.GetExtension(file))
                 {
+                    case ".bmp":
+                        t = SceneManager.Current.Content.Load<Texture, BMPImporter>(Path.GetFileNameWithoutExtension(file));
+                        break;
+
                     case ".png":
                         t = SceneManager.Current.Content.Load<Texture, PNGImporter>(Path.GetFileNameWithoutExtension(file));
                         break;

--- a/Flummery/ContentPipeline/Stainless/DATExporter.cs
+++ b/Flummery/ContentPipeline/Stainless/DATExporter.cs
@@ -40,6 +40,7 @@ namespace Flummery.ContentPipeline.Stainless
                     }
                 }
 
+                m.Optimise();
                 m.ProcessMesh();
 
                 dat.AddMesh(mesh.Name, 0, m);

--- a/Flummery/Graphics/Texture.cs
+++ b/Flummery/Graphics/Texture.cs
@@ -88,13 +88,13 @@ namespace Flummery
             return new Bitmap(64, 64);
         }
 
-        public Bitmap GetThumbnail()
+        public Bitmap GetThumbnail(int maxWidth = 128, bool suppressAlpha = true)
         {
             var bmp = this.supportingDocuments["Source"] as Bitmap;
             if (bmp != null) { return bmp; }
 
             var tdx = this.supportingDocuments["Source"] as ToxicRagers.CarmageddonReincarnation.Formats.TDX;
-            if (tdx != null) { return tdx.Decompress(tdx.GetMipLevelForSize(128), true); }
+            if (tdx != null) { return tdx.Decompress(tdx.GetMipLevelForSize(maxWidth), suppressAlpha); }
 
             return new Bitmap(64, 64);
         }

--- a/Flummery/frmMain.Designer.cs
+++ b/Flummery/frmMain.Designer.cs
@@ -125,6 +125,7 @@
             this.tsmiToolsGeneralProcessAllSetupLOLFiles = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiToolsGeneralProcessAllTXTFilesC1Car = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiToolsGeneralProcessAllXT2Files = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiToolsGeneralProcessAllZADFiles = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiToolsCarmageddon2 = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiToolsCarmageddon2ConvertActorsToEntities = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiToolsCarmageddon2ScaleForCarmageddonReincarnation = new System.Windows.Forms.ToolStripMenuItem();
@@ -134,6 +135,7 @@
             this.tmsiToolsTDR2000RemoveLODFromVehicle = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiHelp = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiHelpAboutFlummery = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiToolsCarmageddonReincarnationBulkUnZAD = new System.Windows.Forms.ToolStripMenuItem();
             this.ssStatus.SuspendLayout();
             this.menu.SuspendLayout();
             this.SuspendLayout();
@@ -713,7 +715,8 @@
             this.tsmiToolsGeneralProcessAllSystemsDamageXMLFiles,
             this.tsmiToolsGeneralProcessAllSetupLOLFiles,
             this.tsmiToolsGeneralProcessAllTXTFilesC1Car,
-            this.tsmiToolsGeneralProcessAllXT2Files});
+            this.tsmiToolsGeneralProcessAllXT2Files,
+            this.tsmiToolsGeneralProcessAllZADFiles});
             this.tsmiToolsGeneralProcessAll.Name = "tsmiToolsGeneralProcessAll";
             this.tsmiToolsGeneralProcessAll.Size = new System.Drawing.Size(152, 22);
             this.tsmiToolsGeneralProcessAll.Text = "Process all...";
@@ -809,6 +812,13 @@
             this.tsmiToolsGeneralProcessAllXT2Files.Text = "XT2 files";
             this.tsmiToolsGeneralProcessAllXT2Files.Click += new System.EventHandler(this.menuNovadromeClick);
             // 
+            // tsmiToolsGeneralProcessAllZADFiles
+            // 
+            this.tsmiToolsGeneralProcessAllZADFiles.Name = "tsmiToolsGeneralProcessAllZADFiles";
+            this.tsmiToolsGeneralProcessAllZADFiles.Size = new System.Drawing.Size(207, 22);
+            this.tsmiToolsGeneralProcessAllZADFiles.Text = "ZAD files";
+            this.tsmiToolsGeneralProcessAllZADFiles.Click += new System.EventHandler(this.menuCarmageddonReincarnationClick);
+            // 
             // tsmiToolsCarmageddon2
             // 
             this.tsmiToolsCarmageddon2.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -835,7 +845,8 @@
             // tsmiToolsCarmageddonReincarnation
             // 
             this.tsmiToolsCarmageddonReincarnation.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsmiToolsCarmageddonReincarnationWheelPreview});
+            this.tsmiToolsCarmageddonReincarnationWheelPreview,
+            this.tsmiToolsCarmageddonReincarnationBulkUnZAD});
             this.tsmiToolsCarmageddonReincarnation.Name = "tsmiToolsCarmageddonReincarnation";
             this.tsmiToolsCarmageddonReincarnation.Size = new System.Drawing.Size(226, 22);
             this.tsmiToolsCarmageddonReincarnation.Text = "Carmageddon Reincarnation";
@@ -876,6 +887,13 @@
             this.tsmiHelpAboutFlummery.Size = new System.Drawing.Size(164, 22);
             this.tsmiHelpAboutFlummery.Text = "About Flummery";
             this.tsmiHelpAboutFlummery.Click += new System.EventHandler(this.menuClick);
+            // 
+            // tsmiToolsCarmageddonReincarnationBulkUnZAD
+            // 
+            this.tsmiToolsCarmageddonReincarnationBulkUnZAD.Name = "tsmiToolsCarmageddonReincarnationBulkUnZAD";
+            this.tsmiToolsCarmageddonReincarnationBulkUnZAD.Size = new System.Drawing.Size(152, 22);
+            this.tsmiToolsCarmageddonReincarnationBulkUnZAD.Text = "Bulk UnZAD";
+            this.tsmiToolsCarmageddonReincarnationBulkUnZAD.Click += new System.EventHandler(this.menuCarmageddonReincarnationClick);
             // 
             // frmMain
             // 
@@ -1003,6 +1021,8 @@
         private System.Windows.Forms.ToolStripMenuItem tsmiFileSaveForCarmageddonReincarnation;
         private System.Windows.Forms.ToolStripMenuItem tmsiToolsTDR2000;
         private System.Windows.Forms.ToolStripMenuItem tmsiToolsTDR2000RemoveLODFromVehicle;
+        private System.Windows.Forms.ToolStripMenuItem tsmiToolsGeneralProcessAllZADFiles;
+        private System.Windows.Forms.ToolStripMenuItem tsmiToolsCarmageddonReincarnationBulkUnZAD;
 
         //private CustomGLControl glcViewport;
 

--- a/Flummery/frmMain.cs
+++ b/Flummery/frmMain.cs
@@ -425,6 +425,7 @@ namespace Flummery
                 case "Structure.xml files":
                 case "SystemsDamage.xml files":
                 case "Setup.lol files":
+                case "ZAD files":
                     processAll(mi.Text);
                     break;
 
@@ -446,6 +447,57 @@ namespace Flummery
                                 }
                             }
                             break;
+                    }
+                    break;
+
+                case "Bulk UnZAD":
+                    if (MessageBox.Show(string.Format("Are you entirely sure?  This will extra ALL ZAD files in and under\r\n{0}\r\nThis will require at least 30gb of free space", Properties.Settings.Default.PathCarmageddonReincarnation), "Totes sure?", MessageBoxButtons.YesNo) == DialogResult.Yes)
+                    {
+                        if (Directory.Exists(Properties.Settings.Default.PathCarmageddonReincarnation))
+                        {
+                            int success = 0;
+                            int fail = 0;
+
+                            ToxicRagers.Helpers.IO.LoopDirectoriesIn(Properties.Settings.Default.PathCarmageddonReincarnation, (d) =>
+                            {
+                                foreach (FileInfo fi in d.GetFiles("*.zad"))
+                                {
+                                    var zad = ToxicRagers.Stainless.Formats.ZAD.Load(fi.FullName);
+                                    int i = 0;
+
+                                    if (zad != null)
+                                    {
+                                        if (!zad.IsVT)
+                                        {
+                                            foreach (var entry in zad.Contents)
+                                            {
+                                                i++;
+
+                                                zad.Extract(entry, Properties.Settings.Default.PathCarmageddonReincarnation);
+
+                                                if (i % 25 == 0)
+                                                {
+                                                    tsslProgress.Text = string.Format("[{0}/{1}] {2} -> {3}", success, fail, fi.Name, entry.Name);
+                                                    Application.DoEvents();
+                                                }
+                                            }
+
+                                            success++;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        fail++; 
+                                    }
+
+                                    tsslProgress.Text = string.Format("[{0}/{1}] {2}", success, fail, fi.FullName.Replace(Properties.Settings.Default.PathCarmageddonReincarnation, ""));
+                                    Application.DoEvents();
+                                }
+                            }
+                            );
+
+                            tsslProgress.Text = string.Format("unZADing complete. {0} success {1} fail", success, fail);
+                        }
                     }
                     break;
             }
@@ -561,6 +613,10 @@ namespace Flummery
 
                             case "txt":
                                 result = ToxicRagers.Carmageddon.Formats.Car.Load(fi.FullName);
+                                break;
+
+                            case "zad":
+                                result = ToxicRagers.Stainless.Formats.ZAD.Load(fi.FullName);
                                 break;
                         }
 

--- a/Flummery/frmTDXConvert.Designer.cs
+++ b/Flummery/frmTDXConvert.Designer.cs
@@ -37,6 +37,7 @@
             this.cmdClose = new System.Windows.Forms.Button();
             this.ofdBrowse = new System.Windows.Forms.OpenFileDialog();
             this.sfdSave = new System.Windows.Forms.SaveFileDialog();
+            this.lblFile = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.pbPreview)).BeginInit();
             this.SuspendLayout();
             // 
@@ -62,7 +63,7 @@
             // 
             // btnSave
             // 
-            this.btnSave.Location = new System.Drawing.Point(530, 80);
+            this.btnSave.Location = new System.Drawing.Point(530, 93);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(186, 23);
             this.btnSave.TabIndex = 4;
@@ -73,29 +74,32 @@
             // lblWidth
             // 
             this.lblWidth.AutoSize = true;
-            this.lblWidth.Location = new System.Drawing.Point(530, 38);
+            this.lblWidth.Location = new System.Drawing.Point(530, 51);
             this.lblWidth.Name = "lblWidth";
-            this.lblWidth.Size = new System.Drawing.Size(0, 13);
+            this.lblWidth.Size = new System.Drawing.Size(68, 13);
             this.lblWidth.TabIndex = 5;
             this.lblWidth.Tag = "Width: {0}";
+            this.lblWidth.Text = "[placeholder]";
             // 
             // lblHeight
             // 
             this.lblHeight.AutoSize = true;
-            this.lblHeight.Location = new System.Drawing.Point(530, 51);
+            this.lblHeight.Location = new System.Drawing.Point(530, 64);
             this.lblHeight.Name = "lblHeight";
-            this.lblHeight.Size = new System.Drawing.Size(0, 13);
+            this.lblHeight.Size = new System.Drawing.Size(68, 13);
             this.lblHeight.TabIndex = 6;
             this.lblHeight.Tag = "Height: {0}";
+            this.lblHeight.Text = "[placeholder]";
             // 
             // lblFileSize
             // 
             this.lblFileSize.AutoSize = true;
-            this.lblFileSize.Location = new System.Drawing.Point(530, 64);
+            this.lblFileSize.Location = new System.Drawing.Point(530, 77);
             this.lblFileSize.Name = "lblFileSize";
-            this.lblFileSize.Size = new System.Drawing.Size(0, 13);
+            this.lblFileSize.Size = new System.Drawing.Size(68, 13);
             this.lblFileSize.TabIndex = 7;
             this.lblFileSize.Tag = "Filesize: {0}";
+            this.lblFileSize.Text = "[placeholder]";
             // 
             // cmdClose
             // 
@@ -111,11 +115,22 @@
             // 
             this.ofdBrowse.FileName = "openFileDialog1";
             // 
+            // lblFile
+            // 
+            this.lblFile.AutoSize = true;
+            this.lblFile.Location = new System.Drawing.Point(530, 38);
+            this.lblFile.Name = "lblFile";
+            this.lblFile.Size = new System.Drawing.Size(68, 13);
+            this.lblFile.TabIndex = 9;
+            this.lblFile.Tag = "{0}";
+            this.lblFile.Text = "[placeholder]";
+            // 
             // frmTDXConvert
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(724, 536);
+            this.Controls.Add(this.lblFile);
             this.Controls.Add(this.cmdClose);
             this.Controls.Add(this.lblFileSize);
             this.Controls.Add(this.lblHeight);
@@ -128,6 +143,7 @@
             this.Name = "frmTDXConvert";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "TDX Convertor";
+            this.Load += new System.EventHandler(this.frmTDXConvert_Load);
             ((System.ComponentModel.ISupportInitialize)(this.pbPreview)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -145,5 +161,6 @@
         private System.Windows.Forms.Button cmdClose;
         private System.Windows.Forms.OpenFileDialog ofdBrowse;
         private System.Windows.Forms.SaveFileDialog sfdSave;
+        private System.Windows.Forms.Label lblFile;
     }
 }

--- a/Flummery/frmTDXConvert.cs
+++ b/Flummery/frmTDXConvert.cs
@@ -17,6 +17,15 @@ namespace Flummery
             InitializeComponent();
         }
 
+
+        private void frmTDXConvert_Load(object sender, EventArgs e)
+        {
+            lblFile.Text = "";
+            lblWidth.Text = "";
+            lblHeight.Text = "";
+            lblFileSize.Text = "";
+        }
+
         private void btnOpen_Click(object sender, EventArgs e)
         {
             ofdBrowse.Filter = "All supported files|*.jpg;*.png;*.tif;*.tga;*.bmp;*.tdx|JPG (*.jpg)|*.jpg|PNG (*.png)|*.png|TIF (*.tif)|*.tif|TGA (*.tga)|*.tga|BMP (*.bmp)|*.bmp|TDX (*.tdx)|*.tdx";
@@ -56,7 +65,8 @@ namespace Flummery
                 {
                     var b = t.GetBitmap();
 
-                    pbPreview.Image = t.GetThumbnail();
+                    pbPreview.Image = t.GetThumbnail(1024, false);
+                    lblFile.Text = string.Format(lblFile.Tag.ToString(), fi.Name);
                     lblWidth.Text = string.Format(lblWidth.Tag.ToString(), b.Width);
                     lblHeight.Text = string.Format(lblHeight.Tag.ToString(), b.Height);
                     lblFileSize.Text = string.Format(lblFileSize.Tag.ToString(), fi.Length);


### PR DESCRIPTION
**ZAD Unpacker**
Can be found under Tools > Carmageddon Reincarnation > Bulk UnZAD

**TDX Converter**
Added support for alpha channels
Increased resolution of preview image (up to 1024x1024)
Added filename into UI

**FBX Importer**
Now supports BMP textures

**DAT Exporter**
Optimises the mesh as part of the export

**ToxicRagers library**
Updated to the latest version, adding support for all functionality introduced in the Carmageddon Reincarnation beta